### PR TITLE
Allow to set the qos parameter

### DIFF
--- a/ansible/playbooks/submit_pycomps.yaml
+++ b/ansible/playbooks/submit_pycomps.yaml
@@ -59,9 +59,16 @@
         - python_interpreter is defined
         - python_interpreter | length > 0
 
+    - name: Set qos
+      set_fact:
+        extra_compss_opts: "{{ extra_compss_opts }} --qos={{ qos }}"
+      when:
+        - qos is defined
+        - qos | length > 0
+
     - name: generate ssh cmd tasks
       set_fact:
-        ssh_cmd_to_run: "module load COMPSs/{{ compss_module_version }}; module load singularity; enqueue_compss {{ extra_compss_opts | default('') }} --qos=debug -d --num_nodes={{ num_nodes }} {{ command }}"
+        ssh_cmd_to_run: "module load COMPSs/{{ compss_module_version }}; module load compss/{{ compss_module_version }}; module load singularity; enqueue_compss {{ extra_compss_opts | default('') }} -d --num_nodes={{ num_nodes }} {{ command }}"
 
     - name: generate ssh cmd args
       set_fact:

--- a/ansible/types.yml
+++ b/ansible/types.yml
@@ -30,6 +30,10 @@ node_types:
         type: integer
         required: false
         default: 1
+      qos:
+        type: string
+        required: false
+        default: debug
       input_data_path:
         type: string
         required: false
@@ -79,6 +83,7 @@ node_types:
             compss_module_version_input: { get_input: [ compss_module_version ] }
             num_nodes: { get_property: [ SELF, num_nodes ] }
             num_nodes_input: { get_input: [ num_nodes ] }
+            qos: { get_property: [ SELF, qos ] }
             command: { get_property: [ SELF, command ] }
             arguments: { get_property: [ SELF, arguments ] }
             input_data_path: { get_property: [ SELF, input_data_path ] }


### PR DESCRIPTION
Previously the qos parameter was hard-coded to "debug" when submitting a PyCOMPSs job.

Now it is exposed as a TOSCA property and can be changed.

However for backward compatibility the default value remains "debug".